### PR TITLE
Configure extension manifest for popup and background worker

### DIFF
--- a/root/manifest.json
+++ b/root/manifest.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": 3,
+  "name": "Prompt Library",
+  "version": "1.0.0",
+  "default_locale": "es",
+  "action": {
+    "default_popup": "popup/index.html"
+  },
+  "icons": {
+    "16": "icons/icon16.png",
+    "32": "icons/icon32.png",
+    "128": "icons/icon128.png"
+  },
+  "permissions": [
+    "storage"
+  ],
+  "background": {
+    "service_worker": "background/worker.js"
+  }
+}


### PR DESCRIPTION
## Summary
- add a manifest v3 configuration with popup and icon entries
- declare the storage permission and background service worker

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68c966e593a4832f94728015f60df52a