### PR TITLE
Add popup UI for managing prompt lists

### DIFF
--- a/root/popup/app.js
+++ b/root/popup/app.js
@@ -1,0 +1,469 @@
+const DEFAULT_STATE = Object.freeze({
+  lists: [],
+  prompts: [],
+  activeListId: null,
+});
+
+const listForm = document.getElementById("listForm");
+const listNameInput = document.getElementById("listName");
+const activeListSelect = document.getElementById("activeListSelect");
+const promptForm = document.getElementById("promptForm");
+const promptTitleInput = document.getElementById("promptTitle");
+const promptContentInput = document.getElementById("promptContent");
+const promptList = document.getElementById("promptList");
+const promptEmptyMessage = document.getElementById("promptEmpty");
+const promptCount = document.getElementById("promptCount");
+const promptFormHelper = document.getElementById("promptFormHelper");
+
+const promptFormFields = promptForm
+  ? Array.from(promptForm.querySelectorAll("input, textarea, button"))
+  : [];
+
+const feedbackTimers = new WeakMap();
+
+const storageAdapter = (() => {
+  if (typeof chrome !== "undefined" && chrome?.storage) {
+    const area = chrome.storage.sync ?? chrome.storage.local;
+    return {
+      async get() {
+        return new Promise((resolve) => {
+          area.get(["promptLibrary"], (result) => {
+            if (chrome.runtime?.lastError) {
+              console.error(
+                "No se pudo leer el almacenamiento",
+                chrome.runtime.lastError,
+              );
+              resolve(null);
+              return;
+            }
+            resolve(result?.promptLibrary ?? null);
+          });
+        });
+      },
+      async set(value) {
+        return new Promise((resolve) => {
+          area.set({ promptLibrary: value }, () => {
+            if (chrome.runtime?.lastError) {
+              console.error(
+                "No se pudo guardar en el almacenamiento",
+                chrome.runtime.lastError,
+              );
+            }
+            resolve();
+          });
+        });
+      },
+    };
+  }
+
+  let fallbackValue = null;
+  const hasLocalStorage =
+    typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+
+  return {
+    async get() {
+      if (fallbackValue) {
+        return cloneState(fallbackValue);
+      }
+      if (hasLocalStorage) {
+        try {
+          const stored = window.localStorage.getItem("promptLibrary");
+          if (!stored) {
+            return null;
+          }
+          fallbackValue = JSON.parse(stored);
+          return cloneState(fallbackValue);
+        } catch (error) {
+          console.error("No se pudo leer localStorage", error);
+        }
+      }
+      return fallbackValue ? cloneState(fallbackValue) : null;
+    },
+    async set(value) {
+      fallbackValue = cloneState(value);
+      if (hasLocalStorage) {
+        try {
+          window.localStorage.setItem(
+            "promptLibrary",
+            JSON.stringify(fallbackValue),
+          );
+        } catch (error) {
+          console.error("No se pudo guardar en localStorage", error);
+        }
+      }
+    },
+  };
+})();
+
+let state = cloneState(DEFAULT_STATE);
+
+init().catch((error) => {
+  console.error("No se pudo inicializar la biblioteca de prompts", error);
+});
+
+async function init() {
+  render();
+  attachEventListeners();
+  const storedState = await storageAdapter.get();
+  const normalizedState = normalizeState(storedState);
+  state = normalizedState;
+  if (!areStatesEqual(storedState, normalizedState)) {
+    await storageAdapter.set(normalizedState);
+  }
+  render();
+}
+
+function attachEventListeners() {
+  if (listForm) {
+    listForm.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const name = listNameInput?.value.trim();
+      if (!name) {
+        return;
+      }
+      await updateState((draft) => {
+        const newList = { id: generateId(), name };
+        draft.lists.push(newList);
+        if (!draft.activeListId) {
+          draft.activeListId = newList.id;
+        }
+      });
+      if (listForm) {
+        listForm.reset();
+      }
+      listNameInput?.focus();
+    });
+  }
+
+  if (activeListSelect) {
+    activeListSelect.addEventListener("change", async (event) => {
+      const selectedId = event.target.value;
+      if (!selectedId || selectedId === state.activeListId) {
+        return;
+      }
+      await updateState((draft) => {
+        if (draft.lists.some((list) => list.id === selectedId)) {
+          draft.activeListId = selectedId;
+        }
+      });
+    });
+  }
+
+  if (promptForm) {
+    promptForm.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      if (!state.activeListId) {
+        return;
+      }
+      const title = promptTitleInput?.value.trim();
+      const content = promptContentInput?.value.trim();
+      if (!title || !content) {
+        return;
+      }
+      await updateState((draft) => {
+        draft.prompts.unshift({
+          id: generateId(),
+          listId: draft.activeListId,
+          title,
+          content,
+        });
+      });
+      if (promptForm) {
+        promptForm.reset();
+      }
+      promptTitleInput?.focus();
+    });
+  }
+}
+
+async function updateState(mutator) {
+  try {
+    const draft = cloneState(state);
+    mutator(draft);
+    const normalized = normalizeState(draft);
+    await storageAdapter.set(normalized);
+    state = normalized;
+    render();
+  } catch (error) {
+    console.error("No se pudo actualizar el estado", error);
+  }
+}
+
+function render() {
+  renderListSelector();
+  renderPromptForm();
+  renderPromptCards();
+}
+
+function renderListSelector() {
+  if (!activeListSelect) {
+    return;
+  }
+  activeListSelect.innerHTML = "";
+  if (state.lists.length === 0) {
+    const option = document.createElement("option");
+    option.value = "";
+    option.textContent = "Sin listas disponibles";
+    option.disabled = true;
+    option.selected = true;
+    activeListSelect.append(option);
+    activeListSelect.disabled = true;
+  } else {
+    activeListSelect.disabled = false;
+    state.lists.forEach((list) => {
+      const option = document.createElement("option");
+      option.value = list.id;
+      option.textContent = list.name;
+      option.selected = list.id === state.activeListId;
+      activeListSelect.append(option);
+    });
+  }
+}
+
+function renderPromptForm() {
+  const hasActiveList = Boolean(state.activeListId);
+  promptFormFields.forEach((field) => {
+    field.disabled = !hasActiveList;
+  });
+  if (promptFormHelper) {
+    if (hasActiveList) {
+      const activeList = state.lists.find(
+        (list) => list.id === state.activeListId,
+      );
+      const listName = activeList?.name ?? "";
+      promptFormHelper.textContent =
+        listName.trim().length > 0
+          ? `El prompt se guardará en «${listName}».`
+          : "El prompt se guardará en la lista seleccionada.";
+    } else {
+      promptFormHelper.textContent =
+        "Selecciona o crea una lista activa para guardar un nuevo prompt.";
+    }
+  }
+}
+
+function renderPromptCards() {
+  if (!promptList || !promptEmptyMessage || !promptCount) {
+    return;
+  }
+
+  promptList.innerHTML = "";
+  const activePrompts = state.activeListId
+    ? state.prompts.filter((prompt) => prompt.listId === state.activeListId)
+    : [];
+
+  if (state.lists.length === 0) {
+    promptEmptyMessage.hidden = false;
+    promptEmptyMessage.textContent =
+      "Crea una lista para comenzar a guardar tus prompts.";
+  } else if (activePrompts.length === 0) {
+    promptEmptyMessage.hidden = false;
+    promptEmptyMessage.textContent = "Todavía no hay prompts en esta lista.";
+  } else {
+    promptEmptyMessage.hidden = true;
+  }
+
+  activePrompts.forEach((prompt) => {
+    promptList.append(createPromptCard(prompt));
+  });
+
+  promptCount.textContent = String(activePrompts.length);
+}
+
+function createPromptCard(prompt) {
+  const article = document.createElement("article");
+  article.className = "prompt-card";
+  article.setAttribute("role", "listitem");
+
+  const title = document.createElement("h3");
+  title.className = "prompt-card__title";
+  title.textContent = prompt.title || "Sin título";
+
+  const content = document.createElement("p");
+  content.className = "prompt-card__content";
+  content.textContent = prompt.content;
+
+  const actions = document.createElement("div");
+  actions.className = "prompt-card__actions";
+
+  const copyButton = document.createElement("button");
+  copyButton.type = "button";
+  copyButton.className = "prompt-card__button";
+  copyButton.textContent = "Copiar";
+  copyButton.addEventListener("click", async () => {
+    const copied = await copyToClipboard(prompt.content);
+    setButtonFeedback(copyButton, copied ? "Copiado" : "Error");
+  });
+
+  const deleteButton = document.createElement("button");
+  deleteButton.type = "button";
+  deleteButton.className = "prompt-card__button prompt-card__button--danger";
+  deleteButton.textContent = "Eliminar";
+  deleteButton.addEventListener("click", async () => {
+    await updateState((draft) => {
+      draft.prompts = draft.prompts.filter((item) => item.id !== prompt.id);
+    });
+  });
+
+  actions.append(copyButton, deleteButton);
+  article.append(title, content, actions);
+  return article;
+}
+
+async function copyToClipboard(text) {
+  if (typeof navigator !== "undefined" && navigator.clipboard) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch (error) {
+      console.error("No se pudo copiar el texto", error);
+    }
+  }
+
+  const fallback = document.createElement("textarea");
+  fallback.value = text;
+  fallback.setAttribute("readonly", "");
+  fallback.style.position = "absolute";
+  fallback.style.left = "-9999px";
+  document.body.appendChild(fallback);
+  fallback.select();
+
+  let success = false;
+  try {
+    success = document.execCommand("copy");
+  } catch (error) {
+    console.error("El método de copia alternativo falló", error);
+  }
+  fallback.remove();
+  return success;
+}
+
+function setButtonFeedback(button, message) {
+  if (!button) {
+    return;
+  }
+  if (feedbackTimers.has(button)) {
+    clearTimeout(feedbackTimers.get(button));
+  }
+  if (!button.dataset.originalLabel) {
+    button.dataset.originalLabel = button.textContent;
+  }
+  button.dataset.feedback = "true";
+  button.textContent = message;
+  const timer = setTimeout(() => {
+    button.dataset.feedback = "false";
+    button.textContent = button.dataset.originalLabel ?? "";
+  }, 1500);
+  feedbackTimers.set(button, timer);
+}
+
+function generateId() {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `id-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function cloneState(source) {
+  return {
+    lists: Array.isArray(source?.lists)
+      ? source.lists.map((list) => ({
+          id: list.id,
+          name: list.name,
+        }))
+      : [],
+    prompts: Array.isArray(source?.prompts)
+      ? source.prompts.map((prompt) => ({
+          id: prompt.id,
+          listId: prompt.listId,
+          title: prompt.title,
+          content: prompt.content,
+        }))
+      : [],
+    activeListId: source?.activeListId ?? null,
+  };
+}
+
+function normalizeState(rawState) {
+  if (!rawState) {
+    return cloneState(DEFAULT_STATE);
+  }
+
+  const listIds = new Set();
+  const lists = Array.isArray(rawState.lists)
+    ? rawState.lists.reduce((acc, item) => {
+        const idValue =
+          typeof item?.id === "string"
+            ? item.id.trim()
+            : item?.id != null
+            ? String(item.id)
+            : "";
+        const nameValue =
+          typeof item?.name === "string" ? item.name.trim() : "";
+        if (!idValue || !nameValue || listIds.has(idValue)) {
+          return acc;
+        }
+        listIds.add(idValue);
+        acc.push({ id: idValue, name: nameValue });
+        return acc;
+      }, [])
+    : [];
+
+  const prompts = Array.isArray(rawState.prompts)
+    ? rawState.prompts.reduce((acc, item) => {
+        const idValue =
+          typeof item?.id === "string"
+            ? item.id.trim()
+            : item?.id != null
+            ? String(item.id)
+            : "";
+        const listIdValue =
+          typeof item?.listId === "string"
+            ? item.listId.trim()
+            : item?.listId != null
+            ? String(item.listId)
+            : "";
+        const titleValue =
+          typeof item?.title === "string" ? item.title.trim() : "";
+        const contentValue =
+          typeof item?.content === "string" ? item.content.trim() : "";
+        if (
+          !idValue ||
+          !listIdValue ||
+          !contentValue ||
+          !listIds.has(listIdValue)
+        ) {
+          return acc;
+        }
+        acc.push({
+          id: idValue,
+          listId: listIdValue,
+          title: titleValue,
+          content: contentValue,
+        });
+        return acc;
+      }, [])
+    : [];
+
+  let activeListId =
+    typeof rawState.activeListId === "string"
+      ? rawState.activeListId
+      : rawState.activeListId != null
+      ? String(rawState.activeListId)
+      : null;
+  if (!activeListId || !listIds.has(activeListId)) {
+    activeListId = lists[0]?.id ?? null;
+  }
+
+  return {
+    lists,
+    prompts,
+    activeListId,
+  };
+}
+
+function areStatesEqual(a, b) {
+  const first = a ?? DEFAULT_STATE;
+  const second = b ?? DEFAULT_STATE;
+  return JSON.stringify(first) === JSON.stringify(second);
+}

--- a/root/popup/index.html
+++ b/root/popup/index.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Biblioteca de Prompts</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="popup">
+      <header class="popup__header">
+        <h1 class="popup__title">Biblioteca de Prompts</h1>
+        <p class="popup__subtitle">Organiza tus listas y guarda tus mejores ideas.</p>
+      </header>
+
+      <section class="card">
+        <h2 class="card__title">Listas</h2>
+        <form id="listForm" class="form" autocomplete="off">
+          <label class="form__label" for="listName">Nombre de la nueva lista</label>
+          <div class="form__row">
+            <input
+              id="listName"
+              class="input"
+              type="text"
+              name="listName"
+              placeholder="Ej. Redes sociales"
+              required
+              maxlength="60"
+            />
+            <button class="button button--primary" type="submit">Crear</button>
+          </div>
+        </form>
+
+        <label class="form__label" for="activeListSelect">Lista activa</label>
+        <select id="activeListSelect" class="input input--select" name="activeList">
+          <option value="" disabled selected>Sin listas disponibles</option>
+        </select>
+      </section>
+
+      <section class="card">
+        <h2 class="card__title">Nuevo prompt</h2>
+        <p id="promptFormHelper" class="form__helper">
+          Selecciona o crea una lista activa para guardar un nuevo prompt.
+        </p>
+        <form id="promptForm" class="form" autocomplete="off">
+          <label class="form__label" for="promptTitle">Título</label>
+          <input
+            id="promptTitle"
+            class="input"
+            type="text"
+            name="promptTitle"
+            placeholder="Ej. Lanzamiento de producto"
+            required
+            maxlength="80"
+          />
+
+          <label class="form__label" for="promptContent">Contenido</label>
+          <textarea
+            id="promptContent"
+            class="input input--textarea"
+            name="promptContent"
+            rows="4"
+            placeholder="Escribe aquí el prompt completo"
+            required
+            maxlength="1500"
+          ></textarea>
+
+          <button class="button button--primary" type="submit">Guardar prompt</button>
+        </form>
+      </section>
+
+      <section class="card">
+        <div class="card__header">
+          <h2 class="card__title">Prompts guardados</h2>
+          <span id="promptCount" class="badge" aria-live="polite">0</span>
+        </div>
+        <p id="promptEmpty" class="empty-message" hidden>
+          Crea una lista para comenzar a guardar tus prompts.
+        </p>
+        <div id="promptList" class="prompt-list" role="list"></div>
+      </section>
+    </main>
+
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/root/popup/styles.css
+++ b/root/popup/styles.css
@@ -1,0 +1,297 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  --background: #f5f7fb;
+  --surface: #ffffff;
+  --surface-alt: #eef2ff;
+  --primary: #4f46e5;
+  --primary-hover: #4338ca;
+  --text: #1f2933;
+  --text-muted: #52616b;
+  --border: rgba(79, 70, 229, 0.15);
+  --shadow: 0 10px 30px rgba(79, 70, 229, 0.08);
+  --radius: 16px;
+  --transition: 160ms ease-in-out;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #101218;
+    --surface: #161b25;
+    --surface-alt: #1f2737;
+    --primary: #6366f1;
+    --primary-hover: #818cf8;
+    --text: #f9fafb;
+    --text-muted: #c7d2fe;
+    --border: rgba(99, 102, 241, 0.35);
+    --shadow: 0 12px 30px rgba(15, 23, 42, 0.65);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  background: linear-gradient(135deg, var(--background), var(--surface-alt));
+  color: var(--text);
+}
+
+.popup {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  width: 360px;
+}
+
+.popup__header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 16px 18px;
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  border-radius: calc(var(--radius) + 4px);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+.popup__title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.popup__subtitle {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px 16px;
+  background: var(--surface);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+.card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.card__title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.form__row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px;
+}
+
+.form__label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.form__helper {
+  margin: 0;
+  font-size: 0.82rem;
+  color: color-mix(in srgb, var(--text-muted) 85%, transparent);
+}
+
+.input {
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+  background-color: color-mix(in srgb, var(--surface) 96%, transparent);
+  color: var(--text);
+  font: inherit;
+  transition: border-color var(--transition), box-shadow var(--transition), transform var(--transition);
+}
+
+.input:focus {
+  outline: none;
+  border-color: color-mix(in srgb, var(--primary) 70%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary) 18%, transparent);
+  transform: translateY(-1px);
+}
+
+.input::placeholder {
+  color: color-mix(in srgb, var(--text-muted) 60%, transparent);
+}
+
+.input--select {
+  appearance: none;
+  background-image: linear-gradient(45deg, transparent 49%, var(--text-muted) 51%),
+    linear-gradient(135deg, var(--text-muted) 49%, transparent 51%);
+  background-position: right 12px top 55%, right 6px top 55%;
+  background-size: 8px 8px;
+  background-repeat: no-repeat;
+}
+
+.input--textarea {
+  resize: vertical;
+  min-height: 120px;
+  line-height: 1.4;
+}
+
+.button {
+  border: none;
+  border-radius: 999px;
+  padding: 10px 18px;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+  transform: none;
+  box-shadow: none;
+}
+
+.button--primary {
+  background: linear-gradient(135deg, var(--primary), color-mix(in srgb, var(--primary-hover) 70%, white));
+  color: white;
+  box-shadow: 0 6px 18px rgba(79, 70, 229, 0.3);
+}
+
+.button--primary:hover,
+.button--primary:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(79, 70, 229, 0.32);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 36px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--surface-alt);
+  border: 1px solid color-mix(in srgb, var(--primary) 20%, transparent);
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--primary);
+}
+
+.empty-message {
+  margin: 0;
+  padding: 12px;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--surface-alt) 70%, transparent);
+  border: 1px dashed color-mix(in srgb, var(--border) 70%, transparent);
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.prompt-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.prompt-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 14px;
+  border: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
+  background: color-mix(in srgb, var(--surface) 96%, transparent);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+}
+
+.prompt-card__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.prompt-card__content {
+  margin: 0;
+  white-space: pre-wrap;
+  line-height: 1.45;
+  color: color-mix(in srgb, var(--text) 92%, transparent);
+}
+
+.prompt-card__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.prompt-card__button {
+  border: none;
+  border-radius: 999px;
+  padding: 8px 14px;
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  color: var(--primary);
+  background: color-mix(in srgb, var(--surface-alt) 88%, transparent);
+  border: 1px solid color-mix(in srgb, var(--primary) 22%, transparent);
+  transition: transform var(--transition), box-shadow var(--transition), background-color var(--transition);
+}
+
+.prompt-card__button:hover,
+.prompt-card__button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(79, 70, 229, 0.18);
+  background: color-mix(in srgb, var(--primary) 15%, var(--surface-alt) 85%);
+}
+
+.prompt-card__button--danger {
+  color: #ef4444;
+  border-color: color-mix(in srgb, #ef4444 35%, transparent);
+  background: color-mix(in srgb, #fee2e2 75%, transparent);
+}
+
+.prompt-card__button--danger:hover,
+.prompt-card__button--danger:focus-visible {
+  box-shadow: 0 8px 20px rgba(239, 68, 68, 0.2);
+  background: color-mix(in srgb, #ef4444 14%, #fee2e2 86%);
+}
+
+.prompt-card__button[aria-live] {
+  position: relative;
+}
+
+.prompt-card__button[data-feedback="true"] {
+  background: var(--primary);
+  color: #ffffff;
+}
+
+@media (max-width: 380px) {
+  .popup {
+    width: 100%;
+  }
+
+  .form__row {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add a popup layout with forms to create lists, create prompts, and select the active list
- style the popup with a polished card-based design and responsive tweaks
- implement client-side logic to persist lists/prompts, filter by the active list, and support copy/delete actions

## Testing
- not run (extension popup UI)


------
https://chatgpt.com/codex/tasks/task_b_68c96855d1ec832fb33010eb9c191483